### PR TITLE
Fix rotation bug in BCA exporter

### DIFF
--- a/export_bca.py
+++ b/export_bca.py
@@ -48,7 +48,7 @@ class AnimBone:
         self.transs = [m.to_translation() for m in transforms]
 
         scales_xyz = [[fix_to_int(v[i], 12) for v in self.scales] for i in range(3)]
-        rots_xyz = [[deg_to_int(v[i]) for v in self.rots] for i in range(3)]
+        rots_xyz = [[(deg_to_int(v[i]) / 16) for v in self.rots] for i in range(3)]
         transs_xyz = [[fix_to_int(v[i], 12) for v in self.transs] for i in range(3)]
 
         self.descs = [AnimDesc(vs, bpe) for vs, bpe in 


### PR DESCRIPTION
The rotation values in a .bca file have to be shifted right by 4 (90° is 0x400, not 0x4000).
Fixes #2 